### PR TITLE
Add tag-based URL converter service

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const app = express();
+const db = new sqlite3.Database('data.db');
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS urls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    original_url TEXT NOT NULL,
+    tags_path TEXT NOT NULL UNIQUE
+  )`);
+});
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+function isValidUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeTags(tags) {
+  return tags.map(tag => tag.replace(/\//g, '∕'));
+}
+
+app.post('/shorten', (req, res) => {
+  let { originalUrl, tags } = req.body;
+
+  if (!isValidUrl(originalUrl)) {
+    return res.status(400).json({ error: 'Invalid URL' });
+  }
+
+  if (!Array.isArray(tags)) {
+    return res.status(400).json({ error: 'Tags must be an array' });
+  }
+
+  if (tags.length === 0 || tags.length > 5) {
+    return res.status(400).json({ error: 'Tags count must be between 1 and 5' });
+  }
+
+  tags = sanitizeTags(tags);
+  const basePath = tags.join('/');
+
+  const findUniquePath = (base, cb) => {
+    let current = base;
+    let suffix = 1;
+    const check = () => {
+      db.get('SELECT 1 FROM urls WHERE tags_path = ?', [current], (err, row) => {
+        if (err) return cb(err);
+        if (row) {
+          current = `${base}/${suffix++}`;
+          check();
+        } else {
+          cb(null, current);
+        }
+      });
+    };
+    check();
+  };
+
+  findUniquePath(basePath, (err, finalPath) => {
+    if (err) return res.status(500).json({ error: 'Database error' });
+
+    db.run('INSERT INTO urls (original_url, tags_path) VALUES (?, ?)', [originalUrl, finalPath], function(err) {
+      if (err) return res.status(500).json({ error: 'Database insert error' });
+      const encoded = finalPath.split('/').map(encodeURIComponent).join('/');
+      const shortUrl = `${req.protocol}://${req.get('host')}/${encoded}`;
+      res.json({ shortUrl });
+    });
+  });
+});
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.get('/*', (req, res) => {
+  const urlPath = req.path.slice(1);
+  if (!urlPath) return res.status(404).send('Not found');
+  db.get('SELECT original_url FROM urls WHERE tags_path = ?', [urlPath], (err, row) => {
+    if (err) return res.status(500).send('Database error');
+    if (row) return res.redirect(302, row.original_url);
+    res.status(404).send('Not found');
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>tag.to</title>
+<style>
+#support-btn { position: fixed; top: 10px; left: 10px; }
+</style>
+</head>
+<body>
+<a id="support-btn" href="https://ctee.kr/place/tag">후원하기</a>
+<h1>tag.to</h1>
+<form id="shorten-form">
+  <input type="text" id="url" placeholder="원본 URL" required />
+  <input type="text" id="tags" placeholder="태그 (쉼표로 구분)" required />
+  <button type="submit">생성</button>
+</form>
+<div id="result"></div>
+<script>
+document.getElementById('shorten-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const originalUrl = document.getElementById('url').value;
+  const tags = document.getElementById('tags').value.split(',').map(t => t.trim()).filter(t => t);
+  const res = await fetch('/shorten', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ originalUrl, tags })
+  });
+  const data = await res.json();
+  if (data.shortUrl) {
+    const a = document.createElement('a');
+    a.href = data.shortUrl;
+    a.textContent = data.shortUrl;
+    a.target = '_blank';
+    const result = document.getElementById('result');
+    result.innerHTML = '';
+    result.appendChild(a);
+  } else if (data.error) {
+    document.getElementById('result').textContent = data.error;
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement Express server with SQLite to create and resolve tag-based short URLs
- Add frontend form with support button linking to ctee.kr
- Configure project metadata and scripts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4b93acc8324b0a31b6cb5bf95a9