### PR TITLE
feat: implement tag-based URL converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+data.db

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>tag.to</title>
+<style>
+body { font-family: sans-serif; margin: 0; padding: 0; }
+#donate { position: fixed; top: 10px; left: 10px; }
+main { margin-top: 60px; display: flex; flex-direction: column; align-items: center; }
+form { display: flex; flex-direction: column; width: 300px; gap: 8px; }
+</style>
+</head>
+<body>
+<a id="donate" href="https://ctee.kr/place/tag">후원하기</a>
+<main>
+<h1>tag.to</h1>
+<form id="form">
+<input type="url" id="url" placeholder="원본 URL" required />
+<input type="text" id="tags" placeholder="태그 (공백으로 구분)" required />
+<button type="submit">생성</button>
+</form>
+<div id="result"></div>
+</main>
+<script>
+const form = document.getElementById('form');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const url = document.getElementById('url').value.trim();
+  const tags = document.getElementById('tags').value.split(/\s+/).filter(Boolean);
+  const res = await fetch('/api/shorten', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, tags })
+  });
+  const data = await res.json();
+  const result = document.getElementById('result');
+  if (res.ok) {
+    const a = document.createElement('a');
+    a.href = data.shortUrl;
+    a.textContent = data.shortUrl;
+    result.innerHTML = '';
+    result.appendChild(a);
+  } else {
+    result.textContent = data.error || 'Error';
+  }
+});
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,88 @@
+const express = require('express');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const app = express();
+const db = new sqlite3.Database(path.join(__dirname, 'data.db'));
+
+db.serialize(() => {
+  db.run('CREATE TABLE IF NOT EXISTS urls (path TEXT PRIMARY KEY, url TEXT NOT NULL)');
+});
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+function sanitizeTag(tag) {
+  return tag.replace(/\//g, '\u2215'); // replace '/' with '∕'
+}
+
+function encodeTags(tags) {
+  return tags.map(t => encodeURIComponent(sanitizeTag(t)));
+}
+
+app.post('/api/shorten', (req, res) => {
+  const { url, tags } = req.body || {};
+  if (!url || !Array.isArray(tags)) {
+    return res.status(400).json({ error: 'url and tags required' });
+  }
+  if (tags.length === 0 || tags.length > 5) {
+    return res.status(400).json({ error: 'tags must be 1-5 items' });
+  }
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (e) {
+    return res.status(400).json({ error: 'invalid url' });
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return res.status(400).json({ error: 'protocol not allowed' });
+  }
+  const encodedTags = encodeTags(tags);
+  const basePath = encodedTags.join('/');
+  let finalPath = basePath;
+  function insertPath(pathToTry, cb, counter = 0) {
+    db.get('SELECT 1 FROM urls WHERE path = ?', pathToTry, (err, row) => {
+      if (err) return cb(err);
+      if (row) {
+        counter += 1;
+        return insertPath(`${basePath}/${counter}`, cb, counter);
+      } else {
+        db.run('INSERT INTO urls(path, url) VALUES (?,?)', pathToTry, url, (err2) => {
+          if (err2) return cb(err2);
+          cb(null, pathToTry);
+        });
+      }
+    });
+  }
+  insertPath(finalPath, (err, storedPath) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'internal error' });
+    }
+    const shortUrl = `${req.protocol}://${req.get('host')}/${storedPath}`;
+    res.json({ shortUrl });
+  });
+});
+
+app.get('*', (req, res) => {
+  // skip API routes
+  if (req.path.startsWith('/api')) return res.status(404).end();
+  const rawSegments = req.path.split('/').filter(Boolean);
+  const encodedSegments = rawSegments.map(encodeURIComponent);
+  const lookupPath = encodedSegments.join('/');
+  db.get('SELECT url FROM urls WHERE path = ?', lookupPath, (err, row) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Internal error');
+    }
+    if (!row) {
+      return res.status(404).send('Not found');
+    }
+    res.redirect(302, row.url);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- build Express + SQLite service that maps tag arrays to short URLs and redirects to original URLs
- enforce tag safety: limit 5 tags, per-segment encoding, slash replacement, numeric suffix for duplicates, protocol whitelist
- add minimal frontend with donation link

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68c6a8c722088324a1f9f7877a5501c2